### PR TITLE
performance(calendar): Prevent unnecessary update on day component

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -584,9 +584,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: a7c83b31436843459a1961bfd74b96033dc77234
+  boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: d58428b28fe1f5070fe993495b0e2eaf701d3820
   FBReactNativeSpec: 225fb0f0ab00493ce0731f954da3658638d9b191
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -599,7 +599,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 476ee3e89abb49e07f822b48323c51c57124b572
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 6351580c827b3b03e5f25aadcf989f582d0b0a86
   HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
@@ -638,4 +638,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 6fb48bcb25807a78bde186d5cbeb4012c3846566
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.15.2

--- a/src/calendar/day/index.tsx
+++ b/src/calendar/day/index.tsx
@@ -12,13 +12,19 @@ import BasicDay, {BasicDayProps} from './basic';
 import PeriodDay from './period';
 
 function areEqual(prevProps: DayProps, nextProps: DayProps) {
-  const prevPropsWithoutMarkDates = omit(prevProps, 'marking');
-  const nextPropsWithoutMarkDates = omit(nextProps, 'marking');
+  const propsToOmit = ['marking', 'onPress', 'onLongPress', 'dayComponent', 'theme'];
+  const prevPropsWithoutMarkDates = omit(prevProps, propsToOmit);
+  const nextPropsWithoutMarkDates = omit(nextProps, propsToOmit);
   const didPropsChange = some(prevPropsWithoutMarkDates, function (value, key) {
     return value !== nextPropsWithoutMarkDates[key];
   });
+  const isThemeEqual = isEqual(prevProps.theme, nextProps.theme);
   const isMarkingEqual = isEqual(prevProps.marking, nextProps.marking);
-  return !didPropsChange && isMarkingEqual;
+
+  // TODO: We still need to compare the onPress and onLongPress callbacks as it is required for the expandable calendars
+  // TODO: Test cases are faling for the expandable calendars because of this
+
+  return !didPropsChange && isMarkingEqual && isThemeEqual;
 }
 
 export interface DayProps extends BasicDayProps {


### PR DESCRIPTION
Calendars where taking too long to update after a day is pressed, this was due unnecessary re-renders on the day component.

The re-renders are triggered due to comparing the `onPress` functions as well as `theme`.

Comparing the `onPress` function will alway return false if the `onPress` function uses `useCallback` or any similar hook that will update the fuction as it changes it's address in the memory therefore triggering a re-render.

However, comparing `onPress` or `onLongPress` is crucial for the `ExpandableCalendar` component as it's `onPress` function has multiple jobs like closing the calendar on day select if it was true. If we stopped comparing the `onPress` or `onLongPress` functions the `ExpandableCalendar` `closeOnDayPress` won't work as expected.

TODO:
- [ ] Find a way to make the `closeOnDayPress` work without having to re-render all of the day components.
- [ ] Make sure all test cases pass.